### PR TITLE
docs: Homebrew install comes from homebrew-core, not a tap

### DIFF
--- a/src/content/docs/threatcl/installation.md
+++ b/src/content/docs/threatcl/installation.md
@@ -8,7 +8,7 @@ Download the latest version from [releases](https://github.com/threatcl/threatcl
 
 ## Homebrew
 
-The following will add a local tap, and install `threatcl` with [Homebrew](https://brew.sh/)
+Install `threatcl` with [Homebrew](https://brew.sh/) — the formula lives in [homebrew-core](https://formulae.brew.sh/formula/threatcl), so no tap is needed:
 
 ```bash title="terminal"
 brew install threatcl


### PR DESCRIPTION
## What

One-line fix on the installation page: it said `brew install threatcl` "will add a local tap". It doesn't — the formula lives in [homebrew-core](https://formulae.brew.sh/formula/threatcl) ([Formula/t/threatcl.rb](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/t/threatcl.rb)), so that command installs straight from core with no tap involved.

Context: the threatcl/homebrew-repo tap is being wound down in [threatcl/homebrew-repo#18](https://github.com/threatcl/homebrew-repo/pull/18) (formula deleted, `tap_migrations.json` → `homebrew/core`), and the same wording was fixed in the CLI README in [threatcl/threatcl#187](https://github.com/threatcl/threatcl/pull/187).

Checked the rest of the page and the site content for `brew tap` / `threatcl/repo` references — this was the only one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)